### PR TITLE
Context.players set to wrong data type

### DIFF
--- a/fbinstant/lib/web/library_fbinstant.js
+++ b/fbinstant/lib/web/library_fbinstant.js
@@ -5,7 +5,7 @@ var FBInstantLibrary = {
     $Context: {
         players: [],
         setPlayers: function(players_to_set) {
-            Context.players = {};
+            Context.players = [];
             for (var i=0; i<players_to_set.length; i++) {
                 player = players_to_set[i];
                 Context.players.push({


### PR DESCRIPTION
Context.players is set to wrong data type and causes an error when trying to use fbinstant.get_players in a multiplayer context.

error from FB: FBInstant_PlatformGetPlayersInContextAsync - error: Context.players.push is not a function